### PR TITLE
Bug fixes

### DIFF
--- a/PulsePlayer/PulsePlayer.xcodeproj/project.pbxproj
+++ b/PulsePlayer/PulsePlayer.xcodeproj/project.pbxproj
@@ -385,7 +385,6 @@
 				C4100D9C1BFB64CF00B3F348 /* Frameworks */,
 				C4100DA01BFB64CF00B3F348 /* Resources */,
 				CF007D011E3902ED001E5B2D /* Embed Frameworks */,
-				CFFEC0971E857291007A80CA /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -403,7 +402,6 @@
 				C45CDBD31BCBA8DC00653D49 /* Sources */,
 				C45CDBD41BCBA8DC00653D49 /* Frameworks */,
 				C45CDBD51BCBA8DC00653D49 /* Resources */,
-				CFFEC0961E85728A007A80CA /* ShellScript */,
 				AB23F99525F7D26000DE9B55 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -546,35 +544,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		CFFEC0961E85728A007A80CA /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Pulse.xcframework/strip-frameworks.sh\"\n";
-		};
-		CFFEC0971E857291007A80CA /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Pulse_tvOS.xcframework/strip-frameworks.sh\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C4100D941BFB64CF00B3F348 /* Sources */ = {

--- a/PulsePlayer/PulsePlayer.xcodeproj/project.pbxproj
+++ b/PulsePlayer/PulsePlayer.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 				C4100D9C1BFB64CF00B3F348 /* Frameworks */,
 				C4100DA01BFB64CF00B3F348 /* Resources */,
 				CF007D011E3902ED001E5B2D /* Embed Frameworks */,
+				CFFEC0971E857291007A80CA /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -562,7 +563,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Pulse.framework/strip-frameworks.sh\"";
+			shellScript = "# bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Pulse.xcframework/strip-frameworks.sh\"\n";
+		};
+		CFFEC0971E857291007A80CA /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Pulse_tvOS.xcframework/strip-frameworks.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/PulsePlayer/PulsePlayer.xcodeproj/project.pbxproj
+++ b/PulsePlayer/PulsePlayer.xcodeproj/project.pbxproj
@@ -9,12 +9,12 @@
 /* Begin PBXBuildFile section */
 		AA609B9D1D1ABA9700A12AE8 /* SkinViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AA609B9C1D1ABA9700A12AE8 /* SkinViewController.m */; };
 		AA609BA01D1AC3F100A12AE8 /* SkinViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA609B9F1D1AC3F100A12AE8 /* SkinViewController.xib */; };
-		AB23F96825F7C8C900DE9B55 /* Pulse.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96625F7C8C900DE9B55 /* Pulse.xcframework */; };
-		AB23F96925F7C8C900DE9B55 /* Pulse.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96625F7C8C900DE9B55 /* Pulse.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		AB23F96A25F7C8C900DE9B55 /* OMSDK_Invidi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */; };
-		AB23F96B25F7C8C900DE9B55 /* OMSDK_Invidi.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		AB23F96F25F7C8D700DE9B55 /* Pulse_tvOS.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96E25F7C8D700DE9B55 /* Pulse_tvOS.xcframework */; };
-		AB23F97025F7C8D700DE9B55 /* Pulse_tvOS.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96E25F7C8D700DE9B55 /* Pulse_tvOS.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AB23F99325F7D26000DE9B55 /* Pulse.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFD55C6A1E3A596500656D06 /* Pulse.xcframework */; };
+		AB23F99425F7D26000DE9B55 /* Pulse.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CFD55C6A1E3A596500656D06 /* Pulse.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AB23F99825F7D26900DE9B55 /* Pulse_tvOS.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFD55C6D1E3A597200656D06 /* Pulse_tvOS.xcframework */; };
+		AB23F99925F7D26900DE9B55 /* Pulse_tvOS.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CFD55C6D1E3A597200656D06 /* Pulse_tvOS.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AB23F99E25F7D27800DE9B55 /* OMSDK_Invidi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */; };
+		AB23F99F25F7D27800DE9B55 /* OMSDK_Invidi.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C405B23F1BFB6D3E00C07A18 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C405B2411BFB6D3E00C07A18 /* Main.storyboard */; };
 		C405B2461BFB6E2400C07A18 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C405B2421BFB6E2400C07A18 /* LaunchScreen.storyboard */; };
 		C405B2471BFB6E2400C07A18 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C405B2441BFB6E2400C07A18 /* Main.storyboard */; };
@@ -81,25 +81,25 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		AB23F99525F7D26000DE9B55 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				AB23F99425F7D26000DE9B55 /* Pulse.xcframework in Embed Frameworks */,
+				AB23F99F25F7D27800DE9B55 /* OMSDK_Invidi.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CF007D011E3902ED001E5B2D /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				AB23F97025F7C8D700DE9B55 /* Pulse_tvOS.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CF070B6D1E9F6F030043348C /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				AB23F96925F7C8C900DE9B55 /* Pulse.xcframework in Embed Frameworks */,
-				AB23F96B25F7C8C900DE9B55 /* OMSDK_Invidi.xcframework in Embed Frameworks */,
+				AB23F99925F7D26900DE9B55 /* Pulse_tvOS.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -110,9 +110,7 @@
 		AA609B9B1D1AB5E600A12AE8 /* SkinViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SkinViewController.h; sourceTree = "<group>"; };
 		AA609B9C1D1ABA9700A12AE8 /* SkinViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SkinViewController.m; sourceTree = "<group>"; };
 		AA609B9F1D1AC3F100A12AE8 /* SkinViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SkinViewController.xib; sourceTree = "<group>"; };
-		AB23F96625F7C8C900DE9B55 /* Pulse.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Pulse.xcframework; path = ../Pulse/Pulse.xcframework; sourceTree = "<group>"; };
 		AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OMSDK_Invidi.xcframework; path = ../Pulse/OMSDK_Invidi.xcframework; sourceTree = "<group>"; };
-		AB23F96E25F7C8D700DE9B55 /* Pulse_tvOS.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Pulse_tvOS.xcframework; path = ../Pulse/Pulse_tvOS.xcframework; sourceTree = "<group>"; };
 		C405B2401BFB6D3E00C07A18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C405B2431BFB6E2400C07A18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C405B2451BFB6E2400C07A18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -165,8 +163,8 @@
 		CF070B711E9FA2D40043348C /* CompanionAdViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CompanionAdViewController.xib; sourceTree = "<group>"; };
 		CFD386E51E9BE1F700316CD9 /* CompanionPlayerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompanionPlayerViewController.h; sourceTree = "<group>"; };
 		CFD386E61E9BE1F700316CD9 /* CompanionPlayerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CompanionPlayerViewController.m; sourceTree = "<group>"; };
-		CFD55C6A1E3A596500656D06 /* Pulse.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pulse.framework; path = ../Pulse/Pulse.framework; sourceTree = "<group>"; };
-		CFD55C6D1E3A597200656D06 /* Pulse_tvOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pulse_tvOS.framework; path = ../Pulse/Pulse_tvOS.framework; sourceTree = "<group>"; };
+		CFD55C6A1E3A596500656D06 /* Pulse.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Pulse.xcframework; path = ../Pulse/Pulse.xcframework; sourceTree = "<group>"; };
+		CFD55C6D1E3A597200656D06 /* Pulse_tvOS.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Pulse_tvOS.xcframework; path = ../Pulse/Pulse_tvOS.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -175,7 +173,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C4100DB31BFB658D00B3F348 /* AVKit.framework in Frameworks */,
-				AB23F96F25F7C8D700DE9B55 /* Pulse_tvOS.xcframework in Frameworks */,
+				AB23F99825F7D26900DE9B55 /* Pulse_tvOS.xcframework in Frameworks */,
 				C4100DB11BFB658800B3F348 /* AVFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -185,9 +183,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				C45CDC1B1BCBCFE900653D49 /* AVFoundation.framework in Frameworks */,
-				AB23F96825F7C8C900DE9B55 /* Pulse.xcframework in Frameworks */,
+				AB23F99325F7D26000DE9B55 /* Pulse.xcframework in Frameworks */,
 				C45CDC151BCBCE4700653D49 /* AVKit.framework in Frameworks */,
-				AB23F96A25F7C8C900DE9B55 /* OMSDK_Invidi.xcframework in Frameworks */,
+				AB23F99E25F7D27800DE9B55 /* OMSDK_Invidi.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -248,9 +246,6 @@
 		C4100DAD1BFB655500B3F348 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				AB23F96E25F7C8D700DE9B55 /* Pulse_tvOS.xcframework */,
-				AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */,
-				AB23F96625F7C8C900DE9B55 /* Pulse.xcframework */,
 				C4100DAF1BFB656200B3F348 /* TVOS */,
 				C4100DAE1BFB655D00B3F348 /* iOS */,
 			);
@@ -260,7 +255,8 @@
 		C4100DAE1BFB655D00B3F348 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				CFD55C6A1E3A596500656D06 /* Pulse.framework */,
+				AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */,
+				CFD55C6A1E3A596500656D06 /* Pulse.xcframework */,
 				C45CDC1A1BCBCFE900653D49 /* AVFoundation.framework */,
 				C45CDC141BCBCE4700653D49 /* AVKit.framework */,
 			);
@@ -270,7 +266,7 @@
 		C4100DAF1BFB656200B3F348 /* TVOS */ = {
 			isa = PBXGroup;
 			children = (
-				CFD55C6D1E3A597200656D06 /* Pulse_tvOS.framework */,
+				CFD55C6D1E3A597200656D06 /* Pulse_tvOS.xcframework */,
 				C4100DB21BFB658D00B3F348 /* AVKit.framework */,
 				C4100DB01BFB658800B3F348 /* AVFoundation.framework */,
 			);
@@ -407,8 +403,8 @@
 				C45CDBD31BCBA8DC00653D49 /* Sources */,
 				C45CDBD41BCBA8DC00653D49 /* Frameworks */,
 				C45CDBD51BCBA8DC00653D49 /* Resources */,
-				CF070B6D1E9F6F030043348C /* Embed Frameworks */,
 				CFFEC0961E85728A007A80CA /* ShellScript */,
+				AB23F99525F7D26000DE9B55 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/PulsePlayer/PulsePlayer.xcodeproj/project.pbxproj
+++ b/PulsePlayer/PulsePlayer.xcodeproj/project.pbxproj
@@ -3,12 +3,18 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		AA609B9D1D1ABA9700A12AE8 /* SkinViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AA609B9C1D1ABA9700A12AE8 /* SkinViewController.m */; };
 		AA609BA01D1AC3F100A12AE8 /* SkinViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA609B9F1D1AC3F100A12AE8 /* SkinViewController.xib */; };
+		AB23F96825F7C8C900DE9B55 /* Pulse.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96625F7C8C900DE9B55 /* Pulse.xcframework */; };
+		AB23F96925F7C8C900DE9B55 /* Pulse.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96625F7C8C900DE9B55 /* Pulse.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AB23F96A25F7C8C900DE9B55 /* OMSDK_Invidi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */; };
+		AB23F96B25F7C8C900DE9B55 /* OMSDK_Invidi.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AB23F96F25F7C8D700DE9B55 /* Pulse_tvOS.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96E25F7C8D700DE9B55 /* Pulse_tvOS.xcframework */; };
+		AB23F97025F7C8D700DE9B55 /* Pulse_tvOS.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB23F96E25F7C8D700DE9B55 /* Pulse_tvOS.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C405B23F1BFB6D3E00C07A18 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C405B2411BFB6D3E00C07A18 /* Main.storyboard */; };
 		C405B2461BFB6E2400C07A18 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C405B2421BFB6E2400C07A18 /* LaunchScreen.storyboard */; };
 		C405B2471BFB6E2400C07A18 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C405B2441BFB6E2400C07A18 /* Main.storyboard */; };
@@ -53,12 +59,8 @@
 		C4D8BC3D1C908ADC001D8E45 /* SkipViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C4D8BC3C1C908ADC001D8E45 /* SkipViewController.xib */; };
 		CF070B701E9F92970043348C /* CompanionAdViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CF070B6F1E9F92970043348C /* CompanionAdViewController.m */; };
 		CF070B721E9FA2D40043348C /* CompanionAdViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CF070B711E9FA2D40043348C /* CompanionAdViewController.xib */; };
-		CF80F5861EAE4E5C0024EA7D /* Pulse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFD55C6A1E3A596500656D06 /* Pulse.framework */; };
-		CF80F5871EAE4E5C0024EA7D /* Pulse.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CFD55C6A1E3A596500656D06 /* Pulse.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CFD386E71E9BE1F700316CD9 /* CompanionPlayerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CFD386E61E9BE1F700316CD9 /* CompanionPlayerViewController.m */; };
 		CFD386E81E9BE1F700316CD9 /* CompanionPlayerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CFD386E61E9BE1F700316CD9 /* CompanionPlayerViewController.m */; };
-		CFD55C6E1E3A597200656D06 /* Pulse_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFD55C6D1E3A597200656D06 /* Pulse_tvOS.framework */; };
-		CFD55C6F1E3A597200656D06 /* Pulse_tvOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CFD55C6D1E3A597200656D06 /* Pulse_tvOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -85,7 +87,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				CFD55C6F1E3A597200656D06 /* Pulse_tvOS.framework in Embed Frameworks */,
+				AB23F97025F7C8D700DE9B55 /* Pulse_tvOS.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -96,7 +98,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				CF80F5871EAE4E5C0024EA7D /* Pulse.framework in Embed Frameworks */,
+				AB23F96925F7C8C900DE9B55 /* Pulse.xcframework in Embed Frameworks */,
+				AB23F96B25F7C8C900DE9B55 /* OMSDK_Invidi.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -107,6 +110,9 @@
 		AA609B9B1D1AB5E600A12AE8 /* SkinViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SkinViewController.h; sourceTree = "<group>"; };
 		AA609B9C1D1ABA9700A12AE8 /* SkinViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SkinViewController.m; sourceTree = "<group>"; };
 		AA609B9F1D1AC3F100A12AE8 /* SkinViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SkinViewController.xib; sourceTree = "<group>"; };
+		AB23F96625F7C8C900DE9B55 /* Pulse.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Pulse.xcframework; path = ../Pulse/Pulse.xcframework; sourceTree = "<group>"; };
+		AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OMSDK_Invidi.xcframework; path = ../Pulse/OMSDK_Invidi.xcframework; sourceTree = "<group>"; };
+		AB23F96E25F7C8D700DE9B55 /* Pulse_tvOS.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Pulse_tvOS.xcframework; path = ../Pulse/Pulse_tvOS.xcframework; sourceTree = "<group>"; };
 		C405B2401BFB6D3E00C07A18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C405B2431BFB6E2400C07A18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C405B2451BFB6E2400C07A18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -168,8 +174,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CFD55C6E1E3A597200656D06 /* Pulse_tvOS.framework in Frameworks */,
 				C4100DB31BFB658D00B3F348 /* AVKit.framework in Frameworks */,
+				AB23F96F25F7C8D700DE9B55 /* Pulse_tvOS.xcframework in Frameworks */,
 				C4100DB11BFB658800B3F348 /* AVFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -179,8 +185,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				C45CDC1B1BCBCFE900653D49 /* AVFoundation.framework in Frameworks */,
+				AB23F96825F7C8C900DE9B55 /* Pulse.xcframework in Frameworks */,
 				C45CDC151BCBCE4700653D49 /* AVKit.framework in Frameworks */,
-				CF80F5861EAE4E5C0024EA7D /* Pulse.framework in Frameworks */,
+				AB23F96A25F7C8C900DE9B55 /* OMSDK_Invidi.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -241,6 +248,9 @@
 		C4100DAD1BFB655500B3F348 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AB23F96E25F7C8D700DE9B55 /* Pulse_tvOS.xcframework */,
+				AB23F96725F7C8C900DE9B55 /* OMSDK_Invidi.xcframework */,
+				AB23F96625F7C8C900DE9B55 /* Pulse.xcframework */,
 				C4100DAF1BFB656200B3F348 /* TVOS */,
 				C4100DAE1BFB655D00B3F348 /* iOS */,
 			);
@@ -379,7 +389,6 @@
 				C4100D9C1BFB64CF00B3F348 /* Frameworks */,
 				C4100DA01BFB64CF00B3F348 /* Resources */,
 				CF007D011E3902ED001E5B2D /* Embed Frameworks */,
-				CFFEC0971E857291007A80CA /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -555,19 +564,6 @@
 			shellPath = /bin/sh;
 			shellScript = "# bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Pulse.framework/strip-frameworks.sh\"";
 		};
-		CFFEC0971E857291007A80CA /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Pulse_tvOS.framework/strip-frameworks.sh\"";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -677,7 +673,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/PulsePlayer/tvos/Info (TVOS).plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.PulsePlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -693,7 +692,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/PulsePlayer/tvos/Info (TVOS).plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.PulsePlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -793,7 +795,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/PulsePlayer/ios/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.PulsePlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -805,7 +810,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/PulsePlayer/ios/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.PulsePlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -816,7 +824,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = PulsePlayerTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.PulsePlayerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PulsePlayer.app/PulsePlayer";
@@ -828,7 +840,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = PulsePlayerTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.PulsePlayerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PulsePlayer.app/PulsePlayer";
@@ -839,7 +855,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = PulsePlayerUITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.PulsePlayerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = PulsePlayer;
@@ -851,7 +871,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = PulsePlayerUITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ooyala.PulsePlayerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = PulsePlayer;

--- a/PulsePlayer/PulsePlayer/SkinViewController.h
+++ b/PulsePlayer/PulsePlayer/SkinViewController.h
@@ -32,6 +32,7 @@
 - (void)showControlsAlways;
 - (void)hideControls;
 - (void)disableCloseButton;
+- (void)changeToPauseIcon;
 
 @property (weak, nonatomic) IBOutlet UIView *contentOverlayView;
 

--- a/PulsePlayer/PulsePlayer/SkinViewController.h
+++ b/PulsePlayer/PulsePlayer/SkinViewController.h
@@ -29,7 +29,7 @@
 
 - (void)toggleControls;
 - (void)showControls;
-- (void)unscheduleHideControls;
+- (void)showControlsAlways;
 - (void)hideControls;
 - (void)disableCloseButton;
 

--- a/PulsePlayer/PulsePlayer/ios/PlayerViewController.m
+++ b/PulsePlayer/PulsePlayer/ios/PlayerViewController.m
@@ -278,11 +278,14 @@ typedef enum : NSUInteger {
   self.adAsset = nil;
   self.skipViewController.view.hidden = YES;
 
-  if (self.contentItem)
-    [self play:self.contentItem];
+    if (self.contentItem){
+        [self.skinViewController changeToPauseIcon];
+        [self play:self.contentItem];
+    }
   else {
     [self.contentAsset preloadWithTimeout:15 success:^(AVAsset *asset) {
       self.contentItem = [AVPlayerItem playerItemWithAsset:asset];
+      [self.skinViewController changeToPauseIcon];
       [self play:self.contentItem];
     } failure:^(OOPulseAdError error) {
       [self dismissViewControllerAnimated:YES completion:nil];
@@ -315,6 +318,7 @@ typedef enum : NSUInteger {
   [INOmidAdSession createOmidAdSessionWithView:self.view pulseVideoAd:ad contentUrl:@"invidi.pulseplayer.com"];
   [self.adAsset preloadWithTimeout:timeout success:^(AVAsset *asset) {
     self.videoAd = ad;
+    [self.skinViewController changeToPauseIcon];
     [self play:[AVPlayerItem playerItemWithAsset:asset]];
   } failure:^(OOPulseAdError error) {
     self.adAsset = nil;

--- a/PulsePlayer/PulsePlayer/ios/PlayerViewController.m
+++ b/PulsePlayer/PulsePlayer/ios/PlayerViewController.m
@@ -296,9 +296,8 @@ typedef enum : NSUInteger {
 
   [self.player pause];
   [self.player replaceCurrentItemWithPlayerItem:nil];
-  [self.skinViewController unscheduleHideControls];
+  [self.skinViewController showControlsAlways];
   self.skinViewController.requiresLinearPlayback = YES;
-
   [self setIsLoading:YES];
 }
 
@@ -316,7 +315,6 @@ typedef enum : NSUInteger {
   [INOmidAdSession createOmidAdSessionWithView:self.view pulseVideoAd:ad contentUrl:@"invidi.pulseplayer.com"];
   [self.adAsset preloadWithTimeout:timeout success:^(AVAsset *asset) {
     self.videoAd = ad;
-    [self.skinViewController unscheduleHideControls];
     [self play:[AVPlayerItem playerItemWithAsset:asset]];
   } failure:^(OOPulseAdError error) {
     self.adAsset = nil;
@@ -395,7 +393,12 @@ typedef enum : NSUInteger {
       NSLog(@"Content paused");
       [self.session contentPaused];
     }
-  }
+  } else if ([self isAssetActive:self.adAsset]) {
+      if (self.state == PlayerStatePlaying) {
+        NSLog(@"Ad paused");
+        [self.videoAd adPaused];
+      }
+    }
 }
 
 - (void)userResumedVideo
@@ -406,7 +409,13 @@ typedef enum : NSUInteger {
       NSLog(@"Content resumed");
       [self.session contentStarted];
     }
-  }
+  } else if ([self isAssetActive:self.adAsset]) {
+      if (self.state == PlayerStatePlaying) {
+        self.pauseAdViewController.ad = nil;
+        NSLog(@"Ad resumed");
+        [self.videoAd adResumed];
+      }
+    }
 }
 
 - (void)playerStateChanged:(OOPlayerState)playerState

--- a/PulsePlayer/PulsePlayer/ios/SkinViewController.m
+++ b/PulsePlayer/PulsePlayer/ios/SkinViewController.m
@@ -190,6 +190,12 @@
   [self scheduleHideControls];
 }
 
+- (void)showControlsAlways
+{
+  self.controlsContainerView.hidden = NO;
+  [self unscheduleHideControls];
+}
+
 - (void)toggleControls
 {
   if (self.controlsContainerView.hidden == YES) {
@@ -211,7 +217,6 @@
   self.isPlaying = false;
   [self.player pause];
   [self.playPauseButton setTitle:ICON_PLAY forState:UIControlStateNormal];
-  [self unscheduleHideControls];
 }
 
 - (void)play
@@ -219,7 +224,6 @@
   self.isPlaying = true;
   [self.player play];
   [self.playPauseButton setTitle:ICON_PAUSE forState:UIControlStateNormal];
-  [self scheduleHideControls];
 }
 
 - (void)enterFullscreen
@@ -289,12 +293,10 @@
 }
 - (IBAction)playPauseButtonPressed
 {
-  [self scheduleHideControls];
   if (self.isPlaying) {
     if ([self.delegate respondsToSelector:@selector(userPausedVideo)])
       [self.delegate userPausedVideo];
     [self pause];
-    
   } else {
     if ([self.delegate respondsToSelector:@selector(userResumedVideo)])
       [self.delegate userResumedVideo];

--- a/PulsePlayer/PulsePlayer/ios/SkinViewController.m
+++ b/PulsePlayer/PulsePlayer/ios/SkinViewController.m
@@ -210,6 +210,12 @@
   [self.closeButtonView setHidden:YES];
 }
 
+- (void)changeToPauseIcon
+{
+    self.isPlaying = true;
+    [self.playPauseButton setTitle:ICON_PAUSE forState:UIControlStateNormal];
+}
+
 #pragma mark - Playback
 
 - (void)pause


### PR DESCRIPTION
This PR contains fix for following bugs/feature improvement:
1. updated project file include ew xcframework.
2. updated  path to strip-frameworks.sh script.
3. Resuming ads after a pause, resulted in hiding player controls after 4 seconds. Now, player controls will be shown for the whole ad.
4. player controls were not shown for midroll/postroll ads. Now, fixed to show player controls for all ads.
5. Skipping Ad from Pause state, interrupted the play of next ad/content. Fixed now.
6. adPaused and adResumed events were not reported. Now, we report them and can see pause/resume events triggered by OM SDK.

